### PR TITLE
Add RUSTC and RUSTDOC variable for rustc and rustdoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 SRC := base.rs Parser.rs ElementBuilder.rs
 RUSTCFLAGS := -O -Z debug-info
+RUSTC ?= rustc
+RUSTDOC ?= rustdoc
 
 all: demo libxml.dummy doc
 
 
 libxml.dummy: xml.rc ${SRC}
-	rustc $< ${RUSTCFLAGS}
+	${RUSTC} $< ${RUSTCFLAGS}
 	touch $@
 
 demo: demo.rs libxml.dummy
-	rustc $< -o $@ -L . ${RUSTCFLAGS}
+	${RUSTC} $< -o $@ -L . ${RUSTCFLAGS}
 
 xmltest: xml.rc ${SRC}
-	rustc $< -o $@ -L . ${RUSTCFLAGS} --test
+	${RUSTC} $< -o $@ -L . ${RUSTCFLAGS} --test
 
 test: xmltest
 	./xmltest
@@ -23,7 +25,7 @@ bench: xmltest
 doc: doc/xml.md
 
 doc/xml.md: xml.rc ${SRC}
-	rustdoc html -o doc $<
+	${RUSTDOC} html -o doc $<
 
 clean:
 	rm -f *.so *.dll *.dylib *.dummy demo xmltest


### PR DESCRIPTION
Necessary for builder which haven't the good version of rustc/rustdoc on their PATH.
