### PR TITLE
Unescape unicode character entities

### DIFF
--- a/src/xml/base.rs
+++ b/src/xml/base.rs
@@ -54,6 +54,10 @@ pub fn unescape(input: &str) -> Result<~str, ~str> {
                 "&gt;"   => result.push_char('>'),
                 "&lt;"   => result.push_char('<'),
                 "&amp;"  => result.push_char('&'),
+                "&#x26;" => result.push_char('&'),
+                "&#x22;" => result.push_char('"'),
+                "&#x3C;" => result.push_char('<'),
+                "&#x3E;" => result.push_char('>'),
                 _ => return Err(ent.into_owned())
             }
             in_entity = false;


### PR DESCRIPTION
While working with some feeds in the wild (Craigslist), I found that craigslist was escaping & < > " using unicode character entities (&x26; &x3C; &x3E and &x22; respectively) as well as the more usually character entities. This pull request allows RustyXML to unescape these additional character entities.
