### PR TITLE
feat: consume a reader rather

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "RustyXML"
-version = "0.3.0"
-authors = [ "Florian Zeitz <florob@babelmonkeys.de>" ]
+name = "xml_stream"
+version = "0.4.0"
+authors = [ "Florian Zeitz <florob@babelmonkeys.de>", "CjS77" ]
 license = "MIT/Apache-2.0"
-homepage = "https://github.com/Florob/RustyXML"
-repository = "https://github.com/Florob/RustyXML"
+homepage = "https://github.com/CjS77/xml_stream"
+repository = "https://github.com/CjS77/xml_stream"
 documentation = "https://docs.babelmonkeys.de/RustyXML/xml/"
 description = "A SAX-like streaming XML parser, and a DOM-like interface based on that"
 keywords = [ "XML", "parser" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "xml"
 
 [dependencies]
-indexmap = { version = "1.7.0", optional = true }
+indexmap = { version = "2.7.0", optional = true }
+log = "0.4.22"
 
 [features]
 ordered_attrs = ["indexmap"]
-bench = []

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -9,7 +9,6 @@
 
 extern crate xml;
 use std::fs::File;
-use std::io::Read;
 
 fn main() {
     let mut args = std::env::args();
@@ -21,7 +20,7 @@ fn main() {
         println!("Usage: {} <file>", name);
         return;
     };
-    let mut rdr = match File::open(path) {
+    let rdr = match File::open(path) {
         Ok(file) => file,
         Err(err) => {
             println!("Couldn't open file: {}", err);
@@ -29,16 +28,9 @@ fn main() {
         }
     };
 
-    let mut p = xml::Parser::new();
+    let p = xml::Parser::new(rdr);
     let mut e = xml::ElementBuilder::new();
 
-    let mut string = String::new();
-    if let Err(err) = rdr.read_to_string(&mut string) {
-        println!("Reading failed: {}", err);
-        std::process::exit(1);
-    };
-
-    p.feed_str(&string);
     for event in p.filter_map(|x| e.handle_event(x)) {
         // println!("{:?}", event);
         match event {

--- a/src/element.rs
+++ b/src/element.rs
@@ -267,10 +267,10 @@ impl FromStr for Element {
     type Err = BuilderError;
     #[inline]
     fn from_str(data: &str) -> Result<Element, BuilderError> {
-        let mut p = Parser::new();
+        let s = data.as_bytes();
+        let mut p = Parser::new(s);
         let mut e = ElementBuilder::new();
 
-        p.feed_str(data);
         p.find_map(|x| e.handle_event(x))
             .unwrap_or(Err(BuilderError::NoElement))
     }

--- a/src/element_builder.rs
+++ b/src/element_builder.rs
@@ -54,10 +54,10 @@ impl From<ParserError> for BuilderError {
 /// ~~~
 /// use xml::{Parser, ElementBuilder};
 ///
-/// let mut parser = Parser::new();
+/// let s = "<example/>".as_bytes();
+/// let mut parser = Parser::new(s);
 /// let mut builder = ElementBuilder::new();
 ///
-/// parser.feed_str("<example/>");
 /// for result in parser.filter_map(|event| builder.handle_event(event)) {
 ///     println!("{}", result.unwrap());
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@
 #![crate_type = "lib"]
 #![forbid(non_camel_case_types)]
 #![warn(missing_docs)]
-// Required for benchmarks
-#![cfg_attr(feature = "bench", feature(test))]
 
 /*!
  * An XML parsing library


### PR DESCRIPTION
As written, data is fed to the parser using `feed_str`, which requires ALL of the data to be fed before you can start listening for events.

This will consume a lot of memory, and is counter to the whole streaming philosophy if you have say, a 10GB XML file that you want to parse.

This commit tweaks the API slightly to accept any `Read`er, and you can start listening to events immediately.